### PR TITLE
hot fixed volttron-lib-boptest-integration didn't include all the cod…

### DIFF
--- a/volttron-lib-boptest-integration/pyproject.toml
+++ b/volttron-lib-boptest-integration/pyproject.toml
@@ -17,7 +17,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "volttron-lib-boptest-integration"
-version = "0.0.1"
+version = "0.0.2"
 description = "A Volttron library for boptest simulation integration."
 authors = ["Kefei Mo <kefei.mo@pnnl.gov>"]
 license = "Apache-2.0"
@@ -25,7 +25,8 @@ maintainers = ["Volttron Team <volttron@pnnl.gov>"]
 readme = "README.md"
 homepage = "https://github.com/eclipse-volttron/volttron-boptest"
 repository = "https://github.com/eclipse-volttron/volttron-boptest"
-packages = [{ include = "boptest_integration", from = "src" }]
+packages = [{ include = "boptest_integration", from = "src" },
+            { include = "boptest_integration/controllers", from = "src" }]
 keywords = ["volttron", "boptest", "simulation", "integration"]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
hot fixed volttron-lib-boptest-integration didn't include all the code under src/

Note: not sure why 
[volttron_lib_boptest_integration-0.1.1rc4.tar.gz](https://files.pythonhosted.org/packages/a1/ba/670098588c707f6c66c6cd46a9fa845ba6da8b1af28dc0ead989755626ac/volttron_lib_boptest_integration-0.1.1rc4.tar.gz) has included all the code. Potentially the poetry version matters. Ref: https://github.com/python-poetry/poetry/issues/3285